### PR TITLE
Refactor toxicache.py for better performance and clarity

### DIFF
--- a/toxicache.py
+++ b/toxicache.py
@@ -1,169 +1,395 @@
 import argparse
-import sys
+import concurrent.futures
+import datetime as dt
 import os
+import random
+import sys
+import threading
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Tuple
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
 import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
-requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
-import concurrent.futures
-import threading
-import random
-import datetime
-from urllib.parse import urlparse, urlencode, parse_qs
 
-REFLECT = 0
-reflect_lock = threading.Lock()
+# -----------------------------
+# Config / constants
+# -----------------------------
 
-def colorize(text, color_code):
+CACHE_HEADERS = [
+    "x-cache",
+    "cf-cache-status",
+    "x-drupal-cache",
+    "x-varnish-cache",
+    "akamai-cache-status",
+    "server-timing",
+    "x-iinfo",
+    "x-nc",
+    "x-hs-cf-cache-status",
+    "x-proxy-cache",
+    "x-cache-hits",
+    "x-cache-status",
+    "x-cache-info",
+    "x-rack-cache",
+    "cdn_cache_status",
+    "x-akamai-cache",
+    "x-akamai-cache-remote",
+    "x-cache-remote",
+]
+
+BANNER = r"""
+_____  ___  __     _   ___    __    ___   _     ____ 
+ | |  / / \ \ \_/ | | / / `  / /\  / / ` | |_| | |_  
+ |_|  \_\_/ /_/ \ |_| \_\_, /_/--\ \_\_, |_| | |_|__ 
+
+                      @xhzeem | v0.2 (python port)
+"""
+
+
+# -----------------------------
+# Thread-local session (fast)
+# -----------------------------
+
+_tls = threading.local()
+
+def get_session(insecure: bool) -> requests.Session:
+    s = getattr(_tls, "session", None)
+    if s is None:
+        s = requests.Session()
+        _tls.session = s
+    # If insecure is true, suppress warnings once globally
+    if insecure:
+        requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+    return s
+
+
+# -----------------------------
+# Utilities
+# -----------------------------
+
+def colorize(text: str, color_code: str) -> str:
     return f"\033[38;5;{color_code}m{text}\033[0m"
 
-def print_banner():
-    banner = """
-_____  ___  __     _   ___    __    ___   _     ____ 
- | |  / / \\ \\ \_/ | | / / %s  / /\\  / / %s | |_| | |_  
- |_|  \\_\\_/ /_/ \\ |_| \\_\\_, /_/--\\ \\_\\_, |_| | |_|__ 
 
-				      @xhzeem | v0.2				
-    """ % ('`', '`')
-    print(colorize(banner, "204"), file=sys.stderr)
+def print_banner() -> None:
+    print(colorize(BANNER, "204"), file=sys.stderr)
 
-def format_headers(headers):
+
+def now_timestamp() -> str:
+    return dt.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+
+
+def normalize_url(url: str) -> Optional[str]:
+    """
+    Normalize URLs:
+    - trims whitespace
+    - if scheme missing, assume https
+    - drops fragments
+    """
+    u = url.strip()
+    if not u:
+        return None
+
+    parsed = urlparse(u)
+    if not parsed.scheme:
+        # Assume https if scheme missing
+        parsed = urlparse("https://" + u)
+
+    # Require host
+    if not parsed.netloc:
+        return None
+
+    # Drop fragments
+    parsed = parsed._replace(fragment="")
+    return urlunparse(parsed)
+
+
+def dedupe_preserve_order(urls: Iterable[str]) -> List[str]:
+    seen = set()
+    out = []
+    for u in urls:
+        if u not in seen:
+            seen.add(u)
+            out.append(u)
+    return out
+
+
+def format_headers(headers: Dict[str, str]) -> str:
     return ", ".join(f"{k}: {v}" for k, v in headers.items())
 
-def has_cache_header(resp):
-    cache_headers = [
-        "x-cache", "cf-cache-status", "x-drupal-cache", "x-varnish-cache", "akamai-cache-status",
-        "server-timing", "x-iinfo", "x-nc", "x-hs-cf-cache-status", "x-proxy-cache",
-        "x-cache-hits", "x-cache-status", "x-cache-info", "x-rack-cache", "cdn_cache_status",
-        "x-akamai-cache", "x-akamai-cache-remote", "x-cache-remote",
-    ]
-    resp_headers_lower = {k.lower(): v for k, v in resp.headers.items()}
-    for header in cache_headers:
-        if header.lower() in resp_headers_lower:
-            return True
-    return False
 
-def toxic_param(target_url):
-    random_value = random.randint(0, 9999)
+def inject_toxic_param(target_url: str, token: str) -> str:
+    """
+    Add/replace toxicache param to bust normalization.
+    Uses a stable per-run token (easier debugging / validation).
+    """
     parsed = urlparse(target_url)
     query = parse_qs(parsed.query)
-    query["toxicache"] = [str(random_value)]
+    query["toxicache"] = [token]
     new_query = urlencode(query, doseq=True)
     return parsed._replace(query=new_query).geturl()
 
-def check_header_reflected(target_url, inj_headers, check_value, user_agent):
-    modified_url = toxic_param(target_url)
+
+def detect_cache_headers(resp: requests.Response) -> List[str]:
+    resp_headers_lower = {k.lower(): k for k in resp.headers.keys()}
+    hits = []
+    for h in CACHE_HEADERS:
+        if h in resp_headers_lower:
+            # Keep original case from response if possible
+            hits.append(resp_headers_lower[h])
+    return hits
+
+
+@dataclass(frozen=True)
+class Probe:
+    headers: Dict[str, str]
+    check: str
+
+
+# -----------------------------
+# Core logic
+# -----------------------------
+
+def check_reflection(
+    url: str,
+    probe: Probe,
+    user_agent: str,
+    timeout: int,
+    insecure: bool,
+    follow_redirects: bool,
+    token: str,
+) -> Tuple[bool, List[str], str]:
+    """
+    Returns:
+      (reflected, cache_header_hits, modified_url)
+    """
+    modified_url = inject_toxic_param(url, token)
+
+    # IMPORTANT: The probe may include User-Agent; keep behavior consistent:
+    # Start with baseline UA then overlay probe headers.
     headers = {"User-Agent": user_agent}
-    headers.update(inj_headers)
+    headers.update(probe.headers)
 
     try:
-        resp = requests.get(modified_url, headers=headers, verify=False, allow_redirects=False, timeout=30)
-    except Exception:
-        return False
+        sess = get_session(insecure)
+        resp = sess.get(
+            modified_url,
+            headers=headers,
+            verify=not insecure,
+            allow_redirects=follow_redirects,
+            timeout=timeout,
+        )
+    except requests.RequestException:
+        return (False, [], modified_url)
 
-    if not has_cache_header(resp):
-        return False
+    cache_hits = detect_cache_headers(resp)
+    if not cache_hits:
+        return (False, [], modified_url)
 
-    # Check response headers
-    for header_values in resp.headers.values():
-        if check_value in header_values:
-            return True
+    # Check response headers values
+    for v in resp.headers.values():
+        if probe.check in str(v):
+            return (True, cache_hits, modified_url)
 
     # Check response body
     try:
-        body = resp.text
-        if check_value in body:
-            return True
+        if probe.check in (resp.text or ""):
+            return (True, cache_hits, modified_url)
     except Exception:
         pass
 
-    return False
+    return (False, cache_hits, modified_url)
 
-def process_check(url, hc, user_agent, output_file):
-    global REFLECT
-    reflected = check_header_reflected(url, hc["headers"], hc["check"], user_agent)
-    if reflected:
-        with reflect_lock:
-            REFLECT += 1
-            print("\n" + colorize("Headers reflected:", "11") + f" [{format_headers(hc['headers'])}]")
-            print(url + "\n")
-            with open(output_file, "a") as f:
-                f.write(f"Headers reflected: {format_headers(hc['headers'])} @ {url}\n")
 
-def main():
-    parser = argparse.ArgumentParser(description="toxicache - Web Cache Poisoning Scanner")
-    parser.add_argument("-i", "--input", type=str, default="", help="Input File Location")
-    parser.add_argument("-o", "--output", type=str, default="", help="Output File Location")
-    parser.add_argument("-ua", "--user-agent", type=str, 
-                        default="Mozilla/5.0 (Macintosh; Intel Mac OS X 12_2_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36",
-                        help="User Agent Header")
-    parser.add_argument("-t", "--threads", type=int, default=(os.cpu_count() or 1) * 5, help="Number of Threads")
+def process_one(
+    url: str,
+    probe: Probe,
+    args,
+    token: str,
+    output_lock: threading.Lock,
+    reflect_counter: "ReflectCounter",
+) -> None:
+    reflected, cache_hits, _ = check_reflection(
+        url=url,
+        probe=probe,
+        user_agent=args.user_agent,
+        timeout=args.timeout,
+        insecure=args.insecure,
+        follow_redirects=args.follow_redirects,
+        token=token,
+    )
+
+    if not reflected:
+        return
+
+    with output_lock:
+        reflect_counter.inc()
+
+        hdrs = format_headers(probe.headers)
+        print("\n" + colorize("Headers reflected:", "11") + f" [{hdrs}]")
+
+        if args.show_cache_headers:
+            print(colorize("Cache headers:", "80") + f" {', '.join(cache_hits)}")
+
+        print(url + "\n")
+
+        with open(args.output, "a", encoding="utf-8") as f:
+            # Keep file format consistent but optionally include cache hits
+            if args.show_cache_headers:
+                f.write(f"Headers reflected: {hdrs} @ {url} | Cache: {', '.join(cache_hits)}\n")
+            else:
+                f.write(f"Headers reflected: {hdrs} @ {url}\n")
+
+
+class ReflectCounter:
+    def __init__(self) -> None:
+        self._n = 0
+        self._lock = threading.Lock()
+
+    def inc(self) -> None:
+        with self._lock:
+            self._n += 1
+
+    def value(self) -> int:
+        with self._lock:
+            return self._n
+
+
+def iter_tasks(urls: List[str], probes: List[Probe]) -> Iterable[Tuple[str, Probe]]:
+    for u in urls:
+        for p in probes:
+            yield (u, p)
+
+
+# -----------------------------
+# CLI / main
+# -----------------------------
+
+def read_urls_from_input(input_path: str) -> List[str]:
+    # stdin wins when piped
+    if not sys.stdin.isatty():
+        raw = [line.strip() for line in sys.stdin if line.strip()]
+    elif input_path:
+        if not os.path.isfile(input_path):
+            raise FileNotFoundError(f"Input file {input_path} not found.")
+        with open(input_path, "r", encoding="utf-8", errors="ignore") as f:
+            raw = [line.strip() for line in f if line.strip()]
+    else:
+        raise ValueError("No input provided (use -i or pipe URLs via stdin).")
+
+    normalized = []
+    for u in raw:
+        nu = normalize_url(u)
+        if nu:
+            normalized.append(nu)
+
+    return dedupe_preserve_order(normalized)
+
+
+def build_probes(payload_host: str) -> List[Probe]:
+    # Keep payload consistent with your script, but make it explicit and centralized.
+    # NOTE: The original script used ":13377" check for X-Forwarded-Proto. That is not
+    # universally correct. If you want port-style reflection checks, use a payload that
+    # actually includes a colon. Here we keep a clean, predictable check: "13377".
+    return [
+        Probe({"X-Forwarded-Host": payload_host}, payload_host),
+        Probe({"X-Forwarded-For": payload_host}, payload_host),
+        Probe({"X-Rewrite-Url": payload_host}, payload_host),
+        Probe({"X-Host": payload_host}, payload_host),
+        Probe({"User-Agent": payload_host}, payload_host),
+        Probe({"Handle": payload_host}, payload_host),
+        Probe({"H0st": payload_host}, payload_host),
+        Probe({"Origin": payload_host}, payload_host),
+        Probe({"Transfer-Encoding": payload_host}, payload_host),
+        Probe({"X-Original-Url": payload_host}, payload_host),
+        Probe({"X-Original-Host": payload_host}, payload_host),
+        Probe({"X-Forwarded-Prefix": payload_host}, payload_host),
+        Probe({"X-Amz-Server-Side-Encryption": payload_host}, payload_host),
+        Probe({"X-Amz-Website-Redirect-Location": payload_host}, payload_host),
+        Probe({"Trailer": payload_host}, payload_host),
+        Probe({"Fastly-Ssl": payload_host}, payload_host),
+        Probe({"Fastly-Host": payload_host}, payload_host),
+        Probe({"Fastly-Ff": payload_host}, payload_host),
+        Probe({"Fastly-Client-ip": payload_host}, payload_host),
+        Probe({"Content-Type": payload_host}, payload_host),
+        Probe({"Api-Version": payload_host}, payload_host),
+        Probe({"AcunetiX-Header": payload_host}, payload_host),
+        Probe({"Accept-Version": payload_host}, payload_host),
+        Probe({"X-Forwarded-Proto": "13377"}, "13377"),
+        Probe({"X-Forwarded-Host": payload_host, "X-Forwarded-Scheme": "http"}, payload_host),
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="toxicachepy - cache-aware header reflection scanner")
+    parser.add_argument("-i", "--input", type=str, default="", help="Input file containing URLs")
+    parser.add_argument("-o", "--output", type=str, default="", help="Output file path")
+    parser.add_argument("-t", "--threads", type=int, default=(os.cpu_count() or 1) * 5, help="Thread count")
+    parser.add_argument(
+        "-ua",
+        "--user-agent",
+        type=str,
+        default="Mozilla/5.0 (Macintosh; Intel Mac OS X 12_2_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36",
+        help="User-Agent header value",
+    )
+    parser.add_argument("--timeout", type=int, default=30, help="Request timeout in seconds")
+    parser.add_argument("--insecure", action="store_true", help="Disable TLS verification (like curl -k)")
+    parser.add_argument("--follow-redirects", action="store_true", help="Follow redirects (default: off)")
+    parser.add_argument("--show-cache-headers", action="store_true", help="Print/log detected cache headers")
+    parser.add_argument("--max-inflight", type=int, default=0,
+                        help="Max queued futures (0 = auto: threads*20). Helps avoid RAM blowups.")
+    parser.add_argument("--payload", type=str, default="xhzeem.me", help="Payload value used for probes")
 
     args = parser.parse_args()
 
-    if args.output == "":
-        now = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        args.output = f"toxicache-{now}.txt"
+    if not args.output:
+        args.output = f"toxicache-{now_timestamp()}.txt"
 
-    print(f"▶ Output will be saved to: {colorize(args.output + '\n', '80')}")
+    # Stable token per run makes debugging and validation cleaner than random per request.
+    token = str(random.randint(0, 9999))
 
-    # Determine input source
-    if not sys.stdin.isatty():
-        urls = [line.strip() for line in sys.stdin if line.strip()]
-    elif args.input:
-        if not os.path.isfile(args.input):
-            print(f"Error: Input file {args.input} not found.", file=sys.stderr)
-            sys.exit(1)
-        with open(args.input) as f:
-            urls = [line.strip() for line in f if line.strip()]
-    else:
-        print("No input provided (use -i or pipe URLs via stdin).", file=sys.stderr)
+    print(f"▶ Output will be saved to: {colorize(args.output, '80')}")
+    print(f"▶ toxicache token: {colorize(token, '80')}\n")
+
+    try:
+        urls = read_urls_from_input(args.input)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
 
     if not urls:
-        print("No URLs to process.", file=sys.stderr)
+        print("No URLs to process after normalization.", file=sys.stderr)
         sys.exit(0)
 
     print_banner()
 
-    headers_to_check = [
-        {"headers": {"X-Forwarded-Host": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"X-Forwarded-For": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"X-Rewrite-Url": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"X-Host": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"User-Agent": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"Handle": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"H0st": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"Origin": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"Transfer-Encoding": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"X-Original-Url": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"X-Original-Host": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"X-Forwarded-Prefix": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"X-Amz-Server-Side-Encryption": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"X-Amz-Website-Redirect-Location": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"Trailer": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"Fastly-Ssl": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"Fastly-Host": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"Fastly-Ff": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"Fastly-Client-ip": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"Content-Type": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"Api-Version": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"AcunetiX-Header": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"Accept-Version": "xhzeem.me"}, "check": "xhzeem.me"},
-        {"headers": {"X-Forwarded-Proto": "13377"}, "check": ":13377"},
-        {"headers": {"X-Forwarded-Host": "xhzeem.me", "X-Forwarded-Scheme": "http"}, "check": "xhzeem.me"},
-    ]
+    probes = build_probes(args.payload)
+
+    output_lock = threading.Lock()
+    reflect_counter = ReflectCounter()
+
+    max_inflight = args.max_inflight if args.max_inflight > 0 else args.threads * 20
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=args.threads) as executor:
-        futures = []
-        for url in urls:
-            for hc in headers_to_check:
-                futures.append(executor.submit(process_check, url, hc, args.user_agent, args.output))
-        # Wait for completion
-        for future in concurrent.futures.as_completed(futures):
-            pass
+        inflight: set[concurrent.futures.Future] = set()
 
-    print(f"\n▶ Number of Reflections Found: {colorize(str(REFLECT), '80')}\n")
+        for (url, probe) in iter_tasks(urls, probes):
+            fut = executor.submit(process_one, url, probe, args, token, output_lock, reflect_counter)
+            inflight.add(fut)
+
+            # Bound memory: if too many queued tasks, wait for some to finish.
+            if len(inflight) >= max_inflight:
+                done, inflight = concurrent.futures.wait(
+                    inflight, return_when=concurrent.futures.FIRST_COMPLETED
+                )
+
+        # Drain remaining
+        if inflight:
+            concurrent.futures.wait(inflight)
+
+    print(f"\n▶ Number of Reflections Found: {colorize(str(reflect_counter.value()), '80')}\n")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Reuses HTTP connections with a thread-local requests.Session()

Avoids building a massive futures list (bounded in-flight tasks)

Normalizes + de-dupes URLs

Adds useful knobs: --timeout, --insecure, --follow-redirects, --show-cache-headers, --max-inflight

Prints and logs which cache headers were detected (optional)

Uses a single per-run token to make findings easier to grep and validate

Fixes weak handling of input and output